### PR TITLE
Fix self-referencing TOC links on Backup and Restore page

### DIFF
--- a/docs/tools/backup-and-restore.md
+++ b/docs/tools/backup-and-restore.md
@@ -13,10 +13,10 @@ Backup and restore scripts are provided that will backup your Graphistry environ
 
 <br>
 
-### [Configuration](#configuration)
-### [Backup](#backup)
-### [Restore](#restore)
-### [Scheduling Backups](#scheduling-backups)
+- [Configuration](#configuration)
+- [Backup](#backup)
+- [Restore](#restore)
+- [Scheduling Backups](#scheduling-backups)
 
 <br>
 


### PR DESCRIPTION
Fix self-referencing TOC links on Backup and Restore page