### PR TITLE
Update admin docs about Frame Ancestor

### DIFF
--- a/docs/app-config/configure.md
+++ b/docs/app-config/configure.md
@@ -74,8 +74,9 @@ grphstry.my-website.org, :80 {
         # disable clients from sniffing the media type
         header_down X-Content-Type-Options nosniff
 
-        # clickjacking protection
-        header_down X-Frame-Options SAMEORIGIN
+        # clickjacking protection (CSP frame-ancestors replaces X-Frame-Options)
+        header_down Content-Security-Policy "frame-ancestors 'self' {$FRAME_ANCESTORS:}"
+        header_down -X-Frame-Options
 
         # keep referrer data off of HTTP connections
         header_down Referrer-Policy no-referrer-when-downgrade
@@ -83,7 +84,14 @@ grphstry.my-website.org, :80 {
 }
 ```
 
-Note: Configuration line `header_down X-Frame-Options SAMEORIGIN` will prevent all cross-origin embedding. By default, public content can be cross-origin embedded while private content cannot. See also `COOKIE_SAMESITE` for enabling authorized private content in cross-origin embeddings.
+Note: `frame-ancestors 'self'` (default) restricts embedding to same-origin only. To allow cross-origin embedding (e.g., Databricks, Jupyter), set `FRAME_ANCESTORS` in `data/config/custom.env`:
+
+```bash
+# Allow specific origins to embed Graphistry in iframes
+FRAME_ANCESTORS=https://*.databricks.com https://*.cloud.databricks.com
+```
+
+`X-Frame-Options` is removed — modern browsers use CSP `frame-ancestors` instead. See also `COOKIE_SAMESITE` for enabling authorized private content in cross-origin embeddings.
 
 #### Application servers
 

--- a/docs/app-config/environment-variables.md
+++ b/docs/app-config/environment-variables.md
@@ -226,6 +226,19 @@ COOKIE_SECURE=true
 COOKIE_SAMESITE=None
 ```
 
+## Security Headers
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FRAME_ANCESTORS` | Space-separated origins allowed to embed Graphistry in iframes (CSP `frame-ancestors`) | `""` (same-origin only) |
+
+**Example** — allow Databricks:
+```bash
+FRAME_ANCESTORS=https://*.databricks.com https://*.cloud.databricks.com
+```
+
+See [TLS Hardening - Caddy](configure.md#caddy) for Caddyfile context.
+
 ## Maps / Geospatial
 
 Enable Kepler.gl-based geospatial map visualizations.

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -53,7 +53,7 @@ Graphistry authentication uses standard web software layers:
    * Unconfigured servers do nto have TLS
    * [Add a TLS certificate](../app-config/configure.md#tls) enables TLS
    * Further consider adding [additional security headers](../app-config/configure.md#caddy)
-   * Cross-origin embedding for unauthenticated visualizations is enabled by default
+   * Same-origin embedding enforced by default via CSP `frame-ancestors 'self'`; set `FRAME_ANCESTORS` in `custom.env` to allow specific cross-origin hosts (e.g., Databricks, Jupyter)
    * To enable cross-origin embedding of authenticated visualizations, [modify the cookie options](../app-config/configure.md#application-servers)
     
 ## Usage

--- a/docs/security/configure-security.md
+++ b/docs/security/configure-security.md
@@ -30,7 +30,7 @@ For futher information, see:
   * As a web Admin, we recommend also creating a non-admin account for yourself
 * Sessions are protected with JWT tokens and HTTP-only CSRF tokens
   * TLS recommended
-  * Cross-origin embedding enabled
+  * Same-origin embedding enforced by default via CSP `frame-ancestors 'self'`; set `FRAME_ANCESTORS` in `custom.env` to allow specific cross-origin hosts
   * Cross-origin embedded login disabled (see TLS configuration section)
 * Visualizations are shared as secure web keys (unguessable IDs)
 * Unique secrets are set in managed host environments (AWS/Azure Marketplace)
@@ -78,7 +78,7 @@ After, there are additional [Caddyfile http/https header settings](https://githu
 
 Enabling **cross-origin authenticated use** is often desirable:
 
-* Cross-origin embedding for unauthenticated visualizations is enabled by default
+* Cross-origin embedding is same-origin only by default (CSP `frame-ancestors 'self'`); set `FRAME_ANCESTORS` in `data/config/custom.env` to allow specific origins (e.g., `https://*.databricks.com`)
 * Cross-origin embedding for authenticated visualizations is disabled by default, enable as part of [TLS configuration](../app-config/configure.md#tls)
 
 ### Firewalls & SSH


### PR DESCRIPTION
```
### Changed                                                                                                                                                                                               

* Replaced `X-Frame-Options SAMEORIGIN` with CSP `frame-ancestors` in Caddyfile TLS hardening example (`docs/app-config/configure.md`)                                                                    
* Updated embedding docs to reflect same-origin-only default; added `FRAME_ANCESTORS` env var for allowing specific cross-origin hosts (`docs/security/configure-security.md`,                            
  `docs/security/authentication.md`)                                                                                                                                                                        * Added `FRAME_ANCESTORS` to environment variables reference under new Security Headers section (`docs/app-config/environment-variables.md`)
```