### PR TITLE
docs(app-config): expand cross-origin embedding cookie guidance

### DIFF
--- a/docs/app-config/configure.md
+++ b/docs/app-config/configure.md
@@ -119,7 +119,7 @@ After restarting, verify in browser DevTools → Application → Cookies on the 
 
 ##### Embedding host requirements
 
-The host embedding the Graphistry iframe must also include the Graphistry origin in its CSP `frame-src` and `child-src` directives, in addition to the cookie flags above. For Louie, see the [Graphistry Iframe Blocked in Louie](https://louieai-documentation.readthedocs.io/en/latest/admin/100_Graphistry_Iframe_Blocked.html) runbook for the full three-way (`OA2_HOST` ↔ Graphistry host ↔ Caddy CSP) checklist.
+The host embedding the Graphistry iframe must also include the Graphistry origin in its CSP `frame-src` and `child-src` directives, in addition to the cookie flags above. For Louie, see the [Graphistry Iframe Blocked in Louie](https://louieai-documentation.readthedocs.io/en/latest/admin/100_Graphistry_Iframe_Blocked.html) runbook for the full three-way (`OA2_HOST` <-> Graphistry host <-> Caddy CSP) checklist.
 
 
 ### Setup free Automatic TLS

--- a/docs/app-config/configure.md
+++ b/docs/app-config/configure.md
@@ -93,13 +93,33 @@ Also inform the Graphistry application servers to use secure cookies in `data/co
 COOKIE_SECURE=true
 ```
 
-For visualizations to be embeddable in different origin sites, enable `COOKIE_SECURE` and then disable `COOKIE_SAMESITE`:
+For visualizations to be embeddable in different origin sites (e.g., embedding into Louie or another web app), enable `COOKIE_SECURE` and explicitly set `COOKIE_SAMESITE=None`:
 
 ```bash
+COOKIE_SECURE=true
 COOKIE_SAMESITE=None
 ```
 
 ... then restart: `./graphistry up -d --force-recreate --no-deps nexus`
+
+##### Defaults and scope
+
+`COOKIE_SECURE` defaults to `false`. `COOKIE_SAMESITE` defaults to `None` when `COOKIE_SECURE=true`, otherwise `Lax`. Both flags must be set for cross-origin iframe embedding to work.
+
+These flags apply to the `SESSION_COOKIE`, `CSRF_COOKIE`, and `JWT_AUTH_COOKIE` attributes (`Secure` and `SameSite`).
+
+##### Verifying cookie behavior
+
+After restarting, verify in browser DevTools → Application → Cookies on the Graphistry host:
+
+* Working: session cookies show `SameSite=None; Secure`
+* Failing: session cookies show `SameSite=Lax` → the browser will drop them inside a cross-origin iframe and the user will see a login loop or a "This content is blocked" message.
+
+`COOKIE_SECURE=true` requires Graphistry to be served over HTTPS — TLS termination at the reverse proxy is sufficient.
+
+##### Embedding host requirements
+
+The host embedding the Graphistry iframe must also include the Graphistry origin in its CSP `frame-src` and `child-src` directives, in addition to the cookie flags above. For Louie, see the [Graphistry Iframe Blocked in Louie](https://louieai-documentation.readthedocs.io/en/latest/admin/100_Graphistry_Iframe_Blocked.html) runbook for the full three-way (`OA2_HOST` ↔ Graphistry host ↔ Caddy CSP) checklist.
 
 
 ### Setup free Automatic TLS

--- a/docs/app-config/configure.md
+++ b/docs/app-config/configure.md
@@ -93,7 +93,7 @@ Also inform the Graphistry application servers to use secure cookies in `data/co
 COOKIE_SECURE=true
 ```
 
-For visualizations to be embeddable in different origin sites (e.g., embedding into Louie or another web app), enable `COOKIE_SECURE` and explicitly set `COOKIE_SAMESITE=None`:
+For visualizations to be embeddable in different origin sites (e.g., embedding into Louie or another web app with a different domain name than Graphistry), enable `COOKIE_SECURE` and explicitly set `COOKIE_SAMESITE=None`:
 
 ```bash
 COOKIE_SECURE=true


### PR DESCRIPTION
## Summary
Expands the existing `Application servers` cookie section under **TLS Hardening** with:

- Explicit defaults: `COOKIE_SECURE` defaults to `false`; `COOKIE_SAMESITE` auto-derives to `None` when `COOKIE_SECURE=true`, else `Lax`.
- Which cookies are affected: `SESSION_COOKIE`, `CSRF_COOKIE`, `JWT_AUTH_COOKIE`.
- A DevTools verification recipe (Working: `SameSite=None; Secure`; Failing: `SameSite=Lax`).
- A sub-section for the embedding-host CSP requirements (`frame-src` / `child-src`) with a cross-link to the new Louie iframe runbook for the end-to-end three-way (`OA2_HOST` ↔ Graphistry host ↔ Caddy CSP) checklist.

## Why
Discovery deployment hit \"This content is blocked\" embedding Graphistry into Louie. Root cause was misaligned cookie flags. Operators were unaware that `COOKIE_SECURE` defaults to `false`, so cross-origin cookies were getting `SameSite=Lax` and the browser dropped them inside the embedded iframe.

Related:
- Issue: graphistry/graphistrygpt#2849
- Trello: https://trello.com/c/i1v1nLMu/228
- Louie runbook PR (merged): https://github.com/graphistry/louie.ai-docs/pull/5

## Test plan
- [ ] \`./build-docs.sh html\` builds without errors
- [ ] Rendered page at \`app-config/configure.html#tls-hardening\` shows the expanded cookie section
- [ ] New sub-headings render: \"Defaults and scope\", \"Verifying cookie behavior\", \"Embedding host requirements\"
- [ ] Cross-link to the Louie iframe runbook resolves (now that PR #5 is merged)

## Files changed
- \`docs/app-config/configure.md\` (+21 / −1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)